### PR TITLE
Typer upgrade

### DIFF
--- a/PseudoInstance.lua
+++ b/PseudoInstance.lua
@@ -87,6 +87,7 @@ local PseudoInstance = {}
 local function DefaultInit(self, ...)
 	self:superinit(...)
 end
+
 local DataTableNames = SortedArray.new{"Events", "Methods", "Properties", "Internals"}
 local MethodIndex = DataTableNames:Find("Methods")
 


### PR DESCRIPTION
- Lightened and re-organized PseudoInstance. Allowed for use with Typer. Fixed a bug where a function couldn't return multiple values properly if one was not `self`.